### PR TITLE
Add example uses of DeepSpeed Flops Profiler

### DIFF
--- a/FlopsProfile/flops_bert.py
+++ b/FlopsProfile/flops_bert.py
@@ -1,0 +1,40 @@
+from functools import partial
+import torch
+# transformers module from huggingface
+from transformers import BertForSequenceClassification, BertTokenizer
+from deepspeed.profiling.flops_profiler import get_model_profile
+
+
+
+def bert_input_constructor(input_shape, tokenizer):
+        fake_seq = ""
+        for _ in range(input_shape[1] - 2):  # ignore the two special tokens [CLS] and [SEP]
+            fake_seq += tokenizer.pad_token
+        inputs = tokenizer([fake_seq] * input_shape[0],
+                           padding = True,
+                           truncation = True,
+                           return_tensors = "pt")
+        labels = torch.tensor([1] * input_shape[0])
+        inputs = dict(inputs)
+        inputs.update({"labels": labels})
+        return inputs
+
+
+with torch.cuda.device(0):
+    tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
+    model = BertForSequenceClassification.from_pretrained('bert-base-uncased')
+    batch_size = 4
+    seq_len = 128
+    enable_profile = True
+    if enable_profile:
+        macs, params = get_model_profile(
+            model,
+            (batch_size, seq_len),
+            input_constructor = partial(bert_input_constructor, tokenizer=tokenizer),
+            print_profile = True,
+            detailed = True,
+        )
+    else:
+        inputs = bert_input_constructor((batch_size, seq_len), tokenizer)
+        outputs = model(inputs)
+

--- a/FlopsProfile/flops_inference.py
+++ b/FlopsProfile/flops_inference.py
@@ -1,0 +1,13 @@
+from deepspeed.profiling.flops_profiler import get_model_profile
+from deepspeed.profiling.flops_profiler import FlopsProfiler
+import torchvision.models as models
+import torch
+
+# Code snippet for Profiling at Inference
+# Profiler output to std, and returns the total MACs and parameters of a model.
+with torch.cuda.device(0):
+    model = models.alexnet()
+    batch_size = 256
+    # Return: The number of multiply-accumulate operations (MACs) and parameters in the model
+    macs, params = get_model_profile(model = model, input_res = (batch_size, 3, 224, 224))
+

--- a/FlopsProfile/flops_prof.sh
+++ b/FlopsProfile/flops_prof.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# DeepSpeed Profiling FlopsProfiler Examples
+
+##################################################################################################################
+# Training Example: non-zero profile-step enables and instructs the global step to FlopsProfiling in training loop
+# flops_train_vision.py
+#   Demo program to use FlopsProfiler on top of microbenchmarking script for torchvision training with ROCm.
+#   To execute:
+#      `python flops_train_vision.py --network <network name> [--profile-step <step_num>] [--batch-size <batch size> ] \
+#	                                                      [--iterations <number of iterations>] [--fp16 <0 or 1> ] \
+#                                                             [--dataparallel|--distributed_dataparallel] \
+#                                                             [--device_ids <comma separated list (no spaces) of GPU indices (0-base) to run dataparallel/distributed_dataparallel>]`
+#      Possible network names are: `alexnet`, `densenet121`, `inception_v3`, `resnet50`, `resnet101`, `SqueezeNet`, `vgg16` etc.
+#
+#      Defaults are profile step 0, training iterations 20, `fp16` off (i.e., 0), and a batch size of 128.
+#      Set non-zero profile step to turn on FlopsProfiling.
+#
+#      `--distributed_dataparallel` will spawn multiple sub-processes and adjust world_size and rank accordingly. Py3.6 ONLY.
+
+python flops_train_vision.py --network resnet50 --amp-opt-level=2 --batch-size=256 --iterations=20 --profile-step=10
+
+
+######################################
+# Inference Example use (another case)
+# python flops_inference.py
+

--- a/FlopsProfile/flops_train_vision.py
+++ b/FlopsProfile/flops_train_vision.py
@@ -1,0 +1,331 @@
+from deepspeed.profiling.flops_profiler import get_model_profile
+from deepspeed.profiling.flops_profiler import FlopsProfiler
+import torchvision.models as models
+import torch
+import torchvision
+import random
+import time
+import argparse
+import os
+import sys
+import math
+import torch.nn as nn
+import torch.multiprocessing as mp
+from utils.fp16util import network_to_half, get_param_copy
+from utils.shufflenet import shufflenet
+from utils.shufflenet_v2 import shufflenet as shufflenet_v2
+try:
+    import apex
+    HAVE_APEX = True
+except:
+    HAVE_APEX = False
+
+def weight_init(m):
+    if isinstance(m, nn.Conv2d):
+        n = m.kernel_size[0] * m.kernel_size[1] * m.out_channels
+        m.weight.data.normal_(0, math.sqrt(2. / n))
+        if m.bias is not None:
+            m.bias.data.zero_()
+    elif isinstance(m, nn.BatchNorm2d):
+        m.weight.data.fill_(1)
+        m.bias.data.zero_()
+
+# num_classes=1000
+models = {
+        "alexnet" :            torchvision.models.alexnet,
+        "densenet121" :        torchvision.models.densenet121,
+        "densenet161" :        torchvision.models.densenet161,
+        "densenet169" :        torchvision.models.densenet169,
+        "densenet201" :        torchvision.models.densenet201,
+        "googlenet" :          torchvision.models.googlenet,
+        "inception_v3" :       torchvision.models.inception_v3,
+        "mnasnet0_5" :         torchvision.models.mnasnet0_5,
+        "mnasnet0_75" :        torchvision.models.mnasnet0_75,
+        "mnasnet1_0" :         torchvision.models.mnasnet1_0,
+        "mnasnet1_3" :         torchvision.models.mnasnet1_3,
+        "mobilenet_v2" :       torchvision.models.mobilenet_v2,
+        "resnet18" :           torchvision.models.resnet18,
+        "resnet34" :           torchvision.models.resnet34,
+        "resnet50" :           torchvision.models.resnet50,
+        "resnet101" :          torchvision.models.resnet101,
+        "resnet152" :          torchvision.models.resnet152,
+        "resnext50" :          torchvision.models.resnext50_32x4d,
+        "resnext50_32x4d" :    torchvision.models.resnext50_32x4d,
+        "resnext101" :         torchvision.models.resnext101_32x8d,
+        "resnext101_32x8d" :   torchvision.models.resnext101_32x8d,
+        "shufflenet" :         shufflenet,
+        "shufflenet_v2" :      shufflenet_v2,
+        "shufflenet_v2_x05" :  torchvision.models.shufflenet_v2_x0_5,
+        "shufflenet_v2_x10" :  torchvision.models.shufflenet_v2_x1_0,
+        "shufflenet_v2_x15" :  torchvision.models.shufflenet_v2_x1_5,
+        "shufflenet_v2_x20" :  torchvision.models.shufflenet_v2_x2_0,
+        "shufflenet_v2_x0_5" : torchvision.models.shufflenet_v2_x0_5,
+        "shufflenet_v2_x1_0" : torchvision.models.shufflenet_v2_x1_0,
+        "shufflenet_v2_x1_5" : torchvision.models.shufflenet_v2_x1_5,
+        "shufflenet_v2_x2_0" : torchvision.models.shufflenet_v2_x2_0,
+        "SqueezeNet" :         torchvision.models.squeezenet1_0,
+        "squeezenet1_0" :      torchvision.models.squeezenet1_0,
+        "SqueezeNet1.1" :      torchvision.models.squeezenet1_1,
+        "squeezenet1_1" :      torchvision.models.squeezenet1_1,
+        "vgg11" :              torchvision.models.vgg11,
+        "vgg13" :              torchvision.models.vgg13,
+        "vgg16" :              torchvision.models.vgg16,
+        "vgg19" :              torchvision.models.vgg19,
+        "vgg11_bn" :           torchvision.models.vgg11_bn,
+        "vgg13_bn" :           torchvision.models.vgg13_bn,
+        "vgg16_bn" :           torchvision.models.vgg16_bn,
+        "vgg19_bn" :           torchvision.models.vgg19_bn,
+        "wide_resnet50_2" :    torchvision.models.wide_resnet50_2,
+        "wide_resnet101_2" :   torchvision.models.wide_resnet101_2,
+}
+
+# newer torchvision models, for backwards compat
+try:
+    models["mobilenet_v3_large"] = torchvision.models.mobilenet_v3_large
+    models["mobilenet_v3_small"] = torchvision.models.mobilenet_v3_small
+except AttributeError:
+    pass
+
+# segmentation models, num_classes=21
+segmentation_models = {
+        "fcn_resnet50" :        torchvision.models.segmentation.fcn_resnet50,
+        "fcn_resnet101" :       torchvision.models.segmentation.fcn_resnet101,
+        "deeplabv3_resnet50" :  torchvision.models.segmentation.deeplabv3_resnet50,
+        "deeplabv3_resnet101" : torchvision.models.segmentation.deeplabv3_resnet101,
+}
+
+# newer torchvision segmentation models, for backwards compat
+try:
+    segmentation_models["deeplabv3_mobilenet_v3_large"] = torchvision.models.segmentation.deeplabv3_mobilenet_v3_large
+    segmentation_models["lraspp_mobilenet_v3_large"] = torchvision.models.segmentation.lraspp_mobilenet_v3_large,
+except AttributeError:
+    pass
+
+def get_network_names():
+    return sorted(list(models.keys()) + list(segmentation_models.keys()))
+
+def get_network(net):
+    # aux_logits=False only used by inception_v3
+    if "inception_v3" == net:
+        return models[net](aux_logits=False).to(device="cuda")
+    elif net in models:
+        return models[net]().to(device="cuda")
+    elif net in segmentation_models:
+        return segmentation_models[net]().to(device="cuda")
+    else:
+        print ("ERROR: not a supported model '%s'" % net)
+        sys.exit(1)
+
+def forwardbackward(inp, optimizer, network, target, amp_opt_level, prof_step=0):
+    # params: prof_step - none zero step to profile
+
+    optimizer.zero_grad()
+
+    if prof_step != 0:
+        prof = FlopsProfiler(network)
+        prof.start_profile()
+
+    out = network(inp)
+    # WIP: googlenet, deeplabv3_*, fcn_* missing log_softmax for this to work
+    loss = torch.nn.functional.cross_entropy(out, target)
+
+    # End profiler here if profile fwd pass only
+
+    if prof_step != 0:
+        if amp_opt_level:
+            with apex.amp.scale_loss(loss, optimizer) as scaled_loss:
+                scaled_loss.backward()
+        else:
+            loss.backward()
+
+        # End profiler here to both fwd &bwd passes
+        flops = prof.get_total_flops(as_string=True)
+        params = prof.get_total_params(as_string=True)
+        prof.print_model_profile(profile_step=prof_step)
+        prof.end_profile()
+
+    else:
+        if amp_opt_level:
+            with apex.amp.scale_loss(loss, optimizer) as scaled_loss:
+                scaled_loss.backward()
+        else:
+            loss.backward()
+    optimizer.step()
+
+def rendezvous(distributed_parameters):
+    print("Initializing process group...")
+    torch.distributed.init_process_group(backend=distributed_parameters['dist_backend'], init_method=distributed_parameters['dist_url'], rank=distributed_parameters['rank'], world_size=distributed_parameters['world_size'])
+    print("Rendezvous complete. Created process group...")
+
+def run_benchmarking_wrapper(net, batch_size, iterations, prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids=None, distributed_parameters=None):
+    if (dataparallel or distributed_dataparallel):
+        ngpus = len(device_ids) if device_ids else torch.cuda.device_count()
+    else:
+        ngpus = 1
+
+    if (distributed_dataparallel):
+        # Assumption below that each process launched with --distributed_dataparallel has the same number of devices visible/specified
+        distributed_parameters['world_size'] = ngpus * distributed_parameters['world_size']
+        distributed_parameters['rank'] = ngpus * distributed_parameters['rank']
+        mp.spawn(run_benchmarking, nprocs=ngpus, args=(ngpus, net, batch_size, iterations, prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids, distributed_parameters))
+    else:
+        run_benchmarking(0, ngpus, net, batch_size, iterations, prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids=None, distributed_parameters=None)
+
+def run_benchmarking(local_rank, ngpus, net, batch_size, iterations, prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids=None, distributed_parameters=None):
+    if device_ids:
+        assert ngpus == len(device_ids)
+        torch.cuda.set_device("cuda:%d" % device_ids[local_rank])
+    else:
+        torch.cuda.set_device("cuda:0")
+
+    network = get_network(net)
+    if "shufflenet" == net:
+        model.apply(weight_init)
+
+    if (run_fp16):
+        network = network_to_half(network)
+
+    if (dataparallel):
+        devices_to_run_on = device_ids if device_ids else list(range(ngpus))
+        print ("INFO: Running dataparallel on devices: {}".format(str(devices_to_run_on)))
+        network = torch.nn.DataParallel(network, device_ids=devices_to_run_on)
+    elif (distributed_dataparallel):
+        distributed_parameters['rank'] += local_rank
+        rendezvous(distributed_parameters)
+        devices_to_run_on = [(device_ids[local_rank] if device_ids else local_rank)]
+        print ("INFO: Rank {} running distributed_dataparallel on devices: {}".format(distributed_parameters['rank'], str(devices_to_run_on)))
+        network = torch.nn.parallel.DistributedDataParallel(network, device_ids=devices_to_run_on)
+        batch_size = int(batch_size / ngpus)
+
+    if (net == "inception_v3"):
+        inp = torch.randn(batch_size, 3, 299, 299, device="cuda")
+    else:
+        inp = torch.randn(batch_size, 3, 224, 224, device="cuda")
+    if (run_fp16):
+        inp = inp.half()
+    if net in models:
+        # number of classes is 1000 for imagenet
+        target = torch.randint(0, 1000, (batch_size,), device="cuda")
+    elif net in segmentation_models:
+        # number of classes is 21 for segmentation
+        target = torch.randint(0, 21, (batch_size,), device="cuda")
+    param_copy = network.parameters()
+    if (run_fp16):
+        param_copy = get_param_copy(network)
+    optimizer = torch.optim.SGD(param_copy, lr = 0.01, momentum = 0.9)
+
+    if (amp_opt_level):
+        network, optimizer = apex.amp.initialize(network, optimizer, opt_level="O%d"%amp_opt_level)
+
+    ## warmup.
+    print ("INFO: running forward and backward for warmup.")
+    forwardbackward(inp, optimizer, network, target, amp_opt_level)
+    forwardbackward(inp, optimizer, network, target, amp_opt_level)
+
+    time.sleep(1)
+    torch.cuda.synchronize()
+
+    ## benchmark.
+    print ("INFO: running the benchmark..")
+    tm = time.time()
+    for i in range(iterations):
+        if i == prof_step:
+            forwardbackward(inp, optimizer, network, target, amp_opt_level, i)
+        else:
+            forwardbackward(inp, optimizer, network, target, amp_opt_level)
+    torch.cuda.synchronize()
+
+    tm2 = time.time()
+    time_per_batch = (tm2 - tm) / iterations
+
+    if run_fp16:
+        dtype = 'FP16'
+    elif amp_opt_level == 1:
+        dtype = 'AMP-O1: Insert automatic FP16 casts around safe Pytorch functions and Tensor methods.'
+    elif amp_opt_level == 2:
+        dtype = 'AMP-O2: FP16 training with FP32 batchnorm and FP32 master weights.'
+    elif amp_opt_level == 3:
+        dtype = 'AMP-O3: Pure FP16 training.'
+    elif amp_opt_level == 4:
+        dtype = 'AMP-O4: Insert automatic BFLOAT16 casts around safe Pytorch functions and Tensor methods.'
+    elif amp_opt_level == 5:
+        dtype = 'AMP-O5: BFLOAT16 training with FP32 batchnorm and FP32 master weights.'
+    else:
+        dtype = 'FP32'
+
+    print ("OK: finished running benchmark..")
+    print ("--------------------SUMMARY--------------------------")
+    print ("Microbenchmark for network : {}".format(net))
+    if (distributed_dataparallel):
+      print ("--------This process: rank " + str(distributed_parameters['rank']) + "--------");
+      print ("Num devices: 1")
+    else:
+      print ("Num devices: {}".format(ngpus))
+    print ("Dtype: {}".format(dtype))
+    print ("Mini batch size [img] : {}".format(batch_size))
+    print ("Time per mini-batch : {}".format(time_per_batch))
+    print ("Throughput [img/sec] : {}".format(batch_size/time_per_batch))
+    if (distributed_dataparallel):
+      print ("")
+      print ("--------Overall (all ranks) (assuming same num/type devices for each rank)--------")
+      world_size = distributed_parameters['world_size']
+      print ("Num devices: {}".format(world_size))
+      print ("Dtype: {}".format(dtype))
+      print ("Mini batch size [img] : {}".format(batch_size*world_size))
+      print ("Time per mini-batch : {}".format(time_per_batch))
+      print ("Throughput [img/sec] : {}".format(batch_size*world_size/time_per_batch))
+
+def main():
+    net = args.network
+    batch_size = args.batch_size
+    iterations = args.iterations
+    prof_step = args.profile_step
+    run_fp16 = args.fp16
+    amp_opt_level = args.amp_opt_level
+    dataparallel = args.dataparallel
+    distributed_dataparallel = args.distributed_dataparallel
+    device_ids_str = args.device_ids
+    if (args.device_ids):
+        device_ids = [int(x) for x in device_ids_str.split(",")]
+    else:
+        device_ids = None
+    distributed_parameters = {}
+    distributed_parameters['rank'] = args.rank
+    distributed_parameters['world_size'] = args.world_size
+    distributed_parameters['dist_backend'] = args.dist_backend
+    distributed_parameters['dist_url'] = args.dist_url
+    # Some arguments are required for distributed_dataparallel
+    if distributed_dataparallel:
+        assert args.rank is not None and \
+               args.world_size is not None and \
+               args.dist_backend is not None and \
+               args.dist_url is not None, "rank, world-size, dist-backend and dist-url are required arguments for distributed_dataparallel"
+
+    run_benchmarking_wrapper(net, batch_size, iterations, prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids, distributed_parameters)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--network", type=str, choices=get_network_names(), required=True, help="Network to run.")
+    parser.add_argument("--batch-size" , type=int, required=False, default=128, help="Batch size (will be split among devices used by this invocation)")
+    parser.add_argument("--iterations", type=int, required=False, default=20, help="Iterations")
+    parser.add_argument("--profile-step", type=int, required=False, default=0, help="The global profiling step")
+    parser.add_argument("--fp16", type=int, required=False, default=0,help="FP16 mixed precision benchmarking")
+    parser.add_argument("--amp-opt-level", type=int, required=False, default=0,help="apex.amp mixed precision benchmarking opt level")
+    parser.add_argument("--dataparallel", action='store_true', required=False, help="Use torch.nn.DataParallel api to run single process on multiple devices. Use only one of --dataparallel or --distributed_dataparallel")
+    parser.add_argument("--distributed_dataparallel", action='store_true', required=False, help="Use torch.nn.parallel.DistributedDataParallel api to run on multiple processes/nodes. The multiple processes need to be launched manually, this script will only launch ONE process per invocation. Use only one of --dataparallel or --distributed_dataparallel")
+    parser.add_argument("--device_ids", type=str, required=False, default=None, help="Comma-separated list (no spaces) to specify which HIP devices (0-indexed) to run dataparallel or distributedDataParallel api on. Might need to use HIP_VISIBLE_DEVICES to limit visiblity of devices to different processes.")
+    parser.add_argument("--rank", type=int, required=False, default=None, help="Rank of this process. Required for --distributed_dataparallel")
+    parser.add_argument("--world-size", type=int, required=False, default=None, help="Total number of ranks/processes. Required for --distributed_dataparallel")
+    parser.add_argument("--dist-backend", type=str, required=False, default=None, help="Backend used for distributed training. Can be one of 'nccl' or 'gloo'. Required for --distributed_dataparallel")
+    parser.add_argument("--dist-url", type=str, required=False, default=None, help="url used for rendezvous of processes in distributed training. Needs to contain IP and open port of master rank0 eg. 'tcp://172.23.2.1:54321'. Required for --distributed_dataparallel")
+
+    args = parser.parse_args()
+
+    if args.fp16 and args.amp_opt_level:
+        print ("ERROR: Cannot use both --fp16 and --amp-opt-level")
+        sys.exit(1)
+    if args.amp_opt_level and not HAVE_APEX:
+        print ("ERROR: You must install apex to use --amp-opt-level")
+        sys.exit(1)
+
+    main()

--- a/FlopsProfile/utils/fp16util.py
+++ b/FlopsProfile/utils/fp16util.py
@@ -1,0 +1,41 @@
+import torch
+import torch.nn as nn
+import os
+
+enable_miopen = (os.getenv("DISABLE_MIOPEN") == None)
+
+class tofp16(nn.Module):
+    def __init__(self):
+        super(tofp16, self).__init__()
+
+    def forward(self, input):
+        return input.half()
+
+def copy_in_params(net, params):
+    net_params = list(net.parameters())
+    for i in range(len(params)):
+        net_params[i].data.copy_(params[i].data)
+
+def set_grad(params, params_with_grad):
+
+    for param, param_w_grad in zip(params, params_with_grad):
+        if param.grad is None:
+            param.grad = torch.nn.Parameter(param.data.new().resize_(*param.data.size()))
+        param.grad.data.copy_(param_w_grad.grad.data)
+
+def get_param_copy(net):
+    param_copy = [param.clone().type(torch.cuda.FloatTensor).detach() for param in net.parameters()]
+    for param in param_copy:
+        param.requires_grad=True
+    return param_copy
+
+def BN_convert_float(module):
+    if (enable_miopen):
+        if isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
+    	    module.float()
+    for child in module.children():
+        BN_convert_float(child)
+    return module
+
+def network_to_half(network):
+    return nn.Sequential(tofp16(), BN_convert_float(network.half()))

--- a/FlopsProfile/utils/shufflenet.py
+++ b/FlopsProfile/utils/shufflenet.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import torch
+import torch.nn as nn
+import math
+import numpy as np
+
+def conv3x3(in_planes, out_planes, stride=1):
+    """3x3 convolution with padding"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride,
+                     padding=1, bias=False)
+
+
+class ShufflenetUnit(nn.Module):
+    expansion = 4
+    def __init__(self, inplanes, planes, stride=1, downsample=None, flag=False):
+        super(ShufflenetUnit, self).__init__()
+        self.downsample = downsample
+        group_num = 3
+        self.flag = flag
+        if self.flag:
+            self.conv1 = nn.Conv2d(inplanes, planes, kernel_size=1, groups=1, bias=False)
+        else:
+            self.conv1 = nn.Conv2d(inplanes, planes, kernel_size=1, groups=group_num, bias=False)
+        self.bn1 = nn.BatchNorm2d(planes)
+
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, stride=stride,
+                               padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+
+        self.conv3 = nn.Conv2d(planes, planes * 4, kernel_size=1, groups=group_num, bias=False)
+        self.bn3 = nn.BatchNorm2d(planes * 4)
+        self.relu = nn.ReLU(inplace=True)
+
+    def _shuffle(self, features, g):
+        channels = features.size()[1] 
+        index = torch.from_numpy(np.asarray([i for i in range(channels)]))
+        index = index.view(-1, g).t().contiguous()
+        index = index.view(-1).cuda()
+        features = features[:, index]
+        return features
+
+    def forward(self, x):
+        residual = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        if not self.flag:
+            out = self._shuffle(out, 3)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+
+        out = self.conv3(out)
+        out = self.bn3(out)
+
+        if self.downsample is not None:
+            residual = self.downsample(x)
+            out = torch.cat((out, residual), 1) 
+        else:
+            out += residual
+        out = self.relu(out)
+
+        return out
+
+class ShuffleNet(nn.Module):
+    inplanes = 24
+    def __init__(self, block, layers, num_classes=1000):
+        super(ShuffleNet, self).__init__()
+        self.conv1 = nn.Conv2d(in_channels=3, out_channels=24, kernel_size=3,
+                               padding=1, stride=2, bias=False)
+        self.bn1 = nn.BatchNorm2d(24)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2)
+
+        self.stage2 = self._make_layer(block, 240, layers[0], True) 
+        self.stage3 = self._make_layer(block, 480, layers[1], False)
+        self.stage4 = self._make_layer(block, 960, layers[2], False)
+
+        self.globalpool = nn.AvgPool2d(kernel_size=7, stride=1)
+        self.fc = nn.Linear(960, num_classes)
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                n = m.kernel_size[0] * m.kernel_size[1] * m.out_channels
+                m.weight.data.normal_(0, math.sqrt(2. / n))
+            elif isinstance(m, nn.BatchNorm2d):
+                m.weight.data.fill_(1)
+                m.bias.data.zero_()
+
+    def _make_layer(self, block, planes, blocks, flag):
+        downsample = nn.Sequential(
+            nn.AvgPool2d(kernel_size=3, stride=2,padding=1)
+        )
+
+        inner_plane = (planes - self.inplanes) / 4
+        layers = []
+        layers.append(block(self.inplanes, inner_plane, 2, downsample, flag=flag))
+        self.inplanes = planes
+        for i in range(blocks):
+            layers.append(block(planes, planes/4))
+
+        return nn.Sequential(*layers) 
+
+    def forward(self,x):
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)         
+
+        x = self.stage2(x)
+        x = self.stage3(x)
+        x = self.stage4(x)
+
+        x = self.globalpool(x)
+        x = x.view(x.size(0), -1)
+        x = self.fc(x)
+
+        return x
+
+
+def shufflenet():
+    model = ShuffleNet(ShufflenetUnit, [3, 7, 3])
+    return model 
+
+if __name__=="__main__":
+    model = shufflenet()
+    print(model)

--- a/FlopsProfile/utils/shufflenet_v2.py
+++ b/FlopsProfile/utils/shufflenet_v2.py
@@ -1,0 +1,171 @@
+import os
+import sys
+import torch
+import torch.nn as nn
+from torch.autograd import Variable
+import math
+import numpy as np
+
+def conv3x3(in_channels, out_channels, stride, padding=1, groups=1):
+    """3x3 convolution"""
+    return nn.Conv2d(in_channels, out_channels,
+                    kernel_size=3, stride=stride, padding=padding,
+                    groups=groups,
+                    bias=False)
+
+def conv1x1(in_channels, out_channels, stride=1):
+    """1x1 convolution"""
+    return nn.Conv2d(in_channels, out_channels,
+                    kernel_size=1, stride=stride,padding=0,
+                    bias=False)
+
+class ShufflenetUnit(nn.Module):
+    def __init__(self, inplanes, planes, stride=1, downsample=None):
+        super(ShufflenetUnit, self).__init__()
+        self.downsample = downsample
+
+        if not self.downsample: #---if not downsample, then channel split, so the channel become half
+            inplanes = inplanes // 2
+            planes = planes // 2
+ 
+        self.conv1x1_1 = conv1x1(in_channels=inplanes, out_channels=planes)
+        self.conv1x1_1_bn = nn.BatchNorm2d(planes)
+
+        self.dwconv3x3 = conv3x3(in_channels=planes, out_channels=planes, stride=stride, groups=planes)
+        self.dwconv3x3_bn= nn.BatchNorm2d(planes)
+
+        self.conv1x1_2 = conv1x1(in_channels=planes, out_channels=planes)
+        self.conv1x1_2_bn = nn.BatchNorm2d(planes)
+
+        self.relu = nn.ReLU(inplace=True)
+
+    def _channel_split(self, features, ratio=0.5):
+        """
+        ratio: c'/c, default value is 0.5
+        """ 
+        size = features.size()[1]
+        split_idx = int(size * ratio)
+        return features[:,:split_idx], features[:,split_idx:]
+
+    def _channel_shuffle(self, features, g=2):
+        channels = features.size()[1] 
+        index = torch.from_numpy(np.asarray([i for i in range(channels)]))
+        index = index.view(-1, g).t().contiguous()
+        index = index.view(-1).cuda()
+        features = features[:, index]
+        return features
+
+    def forward(self, x):
+        if  self.downsample:
+            #x1 = x.clone() #----deep copy x, so where x2 is modified, x1 not be affected
+            x1 = x
+            x2 = x
+        else:
+            x1, x2 = self._channel_split(x)
+
+        #----right branch----- 
+        x2 = self.conv1x1_1(x2)
+        x2 = self.conv1x1_1_bn(x2)
+        x2 = self.relu(x2)
+         
+        x2 = self.dwconv3x3(x2)
+        x2 = self.dwconv3x3_bn(x2)
+    
+        x2 = self.conv1x1_2(x2)
+        x2 = self.conv1x1_2_bn(x2)
+        x2 = self.relu(x2)
+
+        #---left branch-------
+        if self.downsample:
+            x1 = self.downsample(x1)
+
+        x = torch.cat([x1, x2], 1)
+        x = self._channel_shuffle(x)
+        return x
+
+class ShuffleNet(nn.Module):
+    def __init__(self, feature_dim, layers_num, num_classes=1000):
+        super(ShuffleNet, self).__init__()
+        dim1, dim2, dim3, dim4, dim5 = feature_dim
+        self.conv1 = conv3x3(in_channels=3, out_channels=dim1, 
+                            stride=2, padding=1)
+        self.bn1 = nn.BatchNorm2d(dim1)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+        self.stage2 = self._make_layer(dim1, dim2, layers_num[0]) 
+        self.stage3 = self._make_layer(dim2, dim3, layers_num[1])
+        self.stage4 = self._make_layer(dim3, dim4, layers_num[2])
+
+        self.conv5 = conv1x1(in_channels=dim4, out_channels=dim5)
+        self.globalpool = nn.AvgPool2d(kernel_size=7, stride=1)
+        self.fc = nn.Linear(dim5, num_classes)
+
+        """
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                n = m.kernel_size[0] * m.kernel_size[1] * m.out_channels
+                m.weight.data.normal_(0, math.sqrt(2. / n))
+            elif isinstance(m, nn.BatchNorm2d):
+                m.weight.data.fill_(1)
+                m.bias.data.zero_()
+        """
+
+    def _make_layer(self, dim1, dim2, blocks_num):
+        half_channel = dim2 // 2
+        downsample = nn.Sequential(
+            conv3x3(in_channels=dim1, out_channels=dim1, stride=2, padding=1, groups=dim1),
+            nn.BatchNorm2d(dim1),
+            conv1x1(in_channels=dim1, out_channels=half_channel),
+            nn.BatchNorm2d(half_channel),
+            nn.ReLU(inplace=True)
+        )
+
+        layers = []
+        layers.append(ShufflenetUnit(dim1, half_channel, stride=2, downsample=downsample))
+        for i in range(blocks_num):
+            layers.append(ShufflenetUnit(dim2, dim2, stride=1))
+
+        return nn.Sequential(*layers) 
+
+    def forward(self,x):
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        #print("x0.size:\t", x.size())
+        x = self.maxpool(x)         
+        #print("x1.size:\t", x.size())
+        x = self.stage2(x)
+        #print("x2.size:\t", x.size())
+        x = self.stage3(x)
+        #print("x3.size:\t", x.size())
+        x = self.stage4(x)
+        #print("x4.size:\t", x.size())
+        
+        x = self.conv5(x)
+        #print("x5.size:\t", x.size())
+        x = self.globalpool(x)
+        #print("x6.size:\t", x.size())
+
+        x = x.view(-1, 1024)
+        x = self.fc(x)
+
+        return x
+
+features = {
+    "0.5x":[24, 48, 96, 192, 1024],
+    "1x":[24, 116, 232, 464, 1024],
+    "1.5x":[24, 176, 352, 704, 1024],
+    "2x":[24, 244, 488, 976, 2048]
+}
+
+def shufflenet():
+    model = ShuffleNet(features["1x"], [3, 7, 3])
+    return model 
+
+if __name__=="__main__":
+    model = shufflenet().cuda()
+    print(model)
+    x = torch.rand((1,3,224,224))
+    x = Variable(x).cuda()
+    x = model(x)


### PR DESCRIPTION
Add example uses of DeepSpeed FlopsProfiler. Augment torchvision models training loop from micro-bench.
